### PR TITLE
Improve RSS script robustness and option handling

### DIFF
--- a/bin/rsscluster.py
+++ b/bin/rsscluster.py
@@ -14,7 +14,6 @@
 #  python3 rsscluster.py --interval 5 --maxitem 20 "https://paperbay.org/@a.rss" >adulau.xml
 
 import feedparser
-import sys, os
 import time
 import datetime
 import xml.etree.ElementTree as ET
@@ -100,9 +99,8 @@ pattern = "%Y-%m-%d %H:%M:%S"
 
 if options.interval is None:
     options.interval = 1
-    options.output = 1
 
-if options.maxitem == None:
+if options.maxitem is None:
     options.maxitem = 200
 
 
@@ -114,9 +112,6 @@ allitem = {}
 url = args[0]
 
 d = feedparser.parse(url)
-
-if options.interval is None:
-    options.interval = 0
 
 interval = DaysInSec(options.interval)
 

--- a/bin/rsscount.py
+++ b/bin/rsscount.py
@@ -11,7 +11,6 @@
 #
 
 import feedparser
-import sys, os
 import time
 import datetime
 from optparse import OptionParser
@@ -23,8 +22,9 @@ parser = OptionParser(usage)
 
 (options, args) = parser.parse_args()
 
-if args is None:
-    print(usage)
+if not args:
+    parser.print_help()
+    raise SystemExit(1)
 
 counteditem = {}
 
@@ -33,14 +33,12 @@ for url in args:
     d = feedparser.parse(url)
     for el in d.entries:
 
-        if "modified_parsed" in el:
-            eldatetime = datetime.datetime.fromtimestamp(
-                time.mktime(el.modified_parsed)
-            )
-        else:
-            eldatetime = datetime.datetime.fromtimestamp(
-                time.mktime(el.published_parsed)
-            )
+        parsed_date = getattr(el, "modified_parsed", None) or getattr(
+            el, "published_parsed", None
+        ) or getattr(el, "updated_parsed", None)
+        if not parsed_date:
+            continue
+        eldatetime = datetime.datetime.fromtimestamp(time.mktime(parsed_date))
         eventdate = eldatetime.isoformat(" ").split(" ", 1)
         edate = eventdate[0].replace("-", "")
 

--- a/bin/rssfind.py
+++ b/bin/rssfind.py
@@ -41,7 +41,10 @@ def findfeeds(url=None, disable_strict=False):
     if url is None:
         return None
 
-    raw = requests.get(url, headers=headers).text
+    try:
+        raw = requests.get(url, headers=headers, timeout=10).text
+    except requests.RequestException:
+        return []
     results = []
     discovered_feeds = []
     html = bs4(raw, features="lxml")
@@ -55,15 +58,13 @@ def findfeeds(url=None, disable_strict=False):
                     if href:
                         discovered_feeds.append(href)
 
-    parsed_url = urllib.parse.urlparse(url)
-    base = f"{parsed_url.scheme}://{parsed_url.hostname}"
     ahreftags = html.findAll("a")
 
     for a in ahreftags:
         href = a.get("href", None)
         if href:
             if "feed" in href or "rss" in href or "xml" in href:
-                discovered_feeds.append(f"{base}{href}")
+                discovered_feeds.append(urllib.parse.urljoin(url, href))
 
     for url in list(set(discovered_feeds)):
         f = feedparser.parse(url)
@@ -85,7 +86,10 @@ def brutefindfeeds(url=None, disable_strict=False):
     parsed_url = urllib.parse.urlparse(url)
     for path in brute_force_urls:
         url = f"{parsed_url.scheme}://{parsed_url.hostname}/{path}"
-        r = requests.get(url, headers=headers)
+        try:
+            r = requests.get(url, headers=headers, timeout=10)
+        except requests.RequestException:
+            continue
         if r.status_code == 200:
             found_urls.append(url)
     for url in list(set(found_urls)):
@@ -121,7 +125,7 @@ parser.add_option(
 parser.add_option(
     "-d",
     "--disable-strict",
-    action="store_false",
+    action="store_true",
     default=False,
     help="Include empty feeds in the list, default strict is enabled",
 )

--- a/bin/rssmerge.py
+++ b/bin/rssmerge.py
@@ -13,7 +13,6 @@
 #  "https://github.com/adulau.atom" -o markdown --maxitem 20
 
 import feedparser
-import sys, os
 import time
 import datetime
 import hashlib
@@ -70,6 +69,14 @@ def RenderMerge(itemlist, output="text"):
                 break
 
 
+def parse_entry_epoch(entry):
+    for date_attr in ("modified_parsed", "published_parsed", "updated_parsed"):
+        parsed_date = getattr(entry, date_attr, None)
+        if parsed_date:
+            return int(time.mktime(parsed_date))
+    return 0
+
+
 usage = "usage: %prog [options] url"
 parser = OptionParser(usage)
 
@@ -95,9 +102,6 @@ parser.add_option(
     help="output format (text, phtml, markdown), default text",
 )
 
-# 2007-11-10 11:25:51
-pattern = "%Y-%m-%d %H:%M:%S"
-
 (options, args) = parser.parse_args()
 
 allitem = {}
@@ -106,27 +110,19 @@ for url in args:
     d = feedparser.parse(url)
 
     for el in d.entries:
-        if "modified_parsed" in el:
-            eldatetime = datetime.datetime.fromtimestamp(
-                time.mktime(el.modified_parsed)
-            )
-        else:
-            eldatetime = datetime.datetime.fromtimestamp(
-                time.mktime(el.published_parsed)
-            )
-        elepoch = int(time.mktime(time.strptime(str(eldatetime), pattern)))
+        elepoch = parse_entry_epoch(el)
         h = hashlib.md5()
         h.update(el.link.encode("utf-8"))
         linkkey = h.hexdigest()
         allitem[linkkey] = {}
         allitem[linkkey]["link"] = str(el.link)
         allitem[linkkey]["epoch"] = int(elepoch)
-        allitem[linkkey]["updated"] = el.updated
+        allitem[linkkey]["updated"] = getattr(el, "updated", "")
         if "title" in el:
             allitem[linkkey]["title"] = html.unescape(el.title)
         else:
-            cleantext = BeautifulSoup(el.summary, "lxml").text
-            allitem[linkkey]["title"] = cleantext[: options.summarysize]
+            cleantext = BeautifulSoup(getattr(el, "summary", ""), "lxml").text
+            allitem[linkkey]["title"] = cleantext[: int(options.summarysize)]
 
 itemlist = []
 


### PR DESCRIPTION
### Motivation
- Harden network and parsing logic so the small RSS utilities behave more reliably against real-world feeds and network failures.
- Fix option semantics and default handling to make the CLI flags behave as documented and avoid surprising None/str issues.
- Tolerate missing feed metadata (dates, titles, summaries) so merging and counting operations do not crash on malformed entries.

### Description
- `bin/rssfind.py`: add `timeout=10` and `try/except requests.RequestException` around HTTP requests, resolve relative feed links with `urllib.parse.urljoin`, and change `--disable-strict` to `action='store_true'` so the flag enables non-strict listing.
- `bin/rssmerge.py`: introduce `parse_entry_epoch()` to pick the best available date (`modified_parsed`, `published_parsed`, `updated_parsed`), use `getattr` for optional fields like `updated` and `summary`, and ensure `summarysize` is used as an integer; also remove a redundant import.
- `bin/rsscluster.py`: clean up option/default handling by removing an unused `options.output` assignment and normalize `None` checks for `maxitem` and `interval` defaults.
- `bin/rsscount.py`: improve CLI validation by failing early when no args are provided, remove unused imports, and skip entries without any usable parsed date by falling back across date fields.

### Testing
- Ran bytecode checks with `python3 -m py_compile bin/rssfind.py bin/rssmerge.py bin/rsscluster.py bin/rsscount.py`, which completed successfully.
- Attempted to run CLI smoke checks (`--help`) for the scripts but runtime execution failed in this environment due to the `feedparser` dependency not being installed; parsing-related runtime validation therefore could not be completed here.
- No unit tests were present in the repository; changes were kept minimal and focused on defensive handling to reduce risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada928b32c83248918492ca0d2c013)