### PR TITLE
Fix rsscluster crash when final clustered list is empty

### DIFF
--- a/bin/rsscluster.py
+++ b/bin/rsscluster.py
@@ -169,7 +169,7 @@ for el in d.entries:
     previousepoch.append(elepoch)
 
 # if last cluster list was not complete, we add the time period information.
-if len(previousepoch):
+if len(previousepoch) and len(clusteredepoch):
     value = clusteredepoch.pop()
     starttimetuple = datetime.datetime.fromtimestamp(previousepoch[0])
     endttimetuple = datetime.datetime.fromtimestamp(previousepoch.pop())
@@ -180,7 +180,10 @@ if len(previousepoch):
         + " to: "
         + str(endttimetuple.ctime())
     )
+    startdatelist = str(starttimetuple.strftime(pattern)), str(clusteredepoch[-1])
+    tcluster.append(startdatelist)
     del previousepoch[0 : len(previousepoch)]
+    del clusteredepoch[0 : len(clusteredepoch)]
 
 
 tcluster.sort()


### PR DESCRIPTION
### Motivation
- Avoid an `IndexError: pop from empty list` when the feed ends with no accumulated `clusteredepoch` entry by guarding finalization logic.

### Description
- Add a guard so the finalization block only runs when both `previousepoch` and `clusteredepoch` are non-empty to prevent popping from an empty list.
- Append the finalized trailing cluster into `tcluster` so the last cluster is included in the generated RSS output.
- Clear `clusteredepoch` after finalization to keep internal buffers consistent.

### Testing
- Successfully compiled the script with `python3 -m py_compile bin/rsscluster.py`.
- Attempted to run `python3 bin/rsscluster.py --interval 5 --maxitem 20 "https://paperbay.org/@a.rss"` but the run was blocked in this environment due to the missing `feedparser` dependency.
- Attempted to install requirements with `python3 -m pip install -r REQUIREMENTS` but the package index was inaccessible due to proxy restrictions, so runtime execution could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adabf1f3908324aab3acd3bc3a8f52)