### PR TITLE
Add Atom keyword matching in rssfind feed discovery

### DIFF
--- a/bin/rssfind.py
+++ b/bin/rssfind.py
@@ -53,7 +53,12 @@ def findfeeds(url=None, disable_strict=False):
         for f in feed_urls:
             tag = f.get("type", None)
             if tag:
-                if "feed" in tag or "rss" in tag or "xml" in tag:
+                if (
+                    "feed" in tag
+                    or "rss" in tag
+                    or "atom" in tag
+                    or "xml" in tag
+                ):
                     href = f.get("href", None)
                     if href:
                         discovered_feeds.append(href)
@@ -63,7 +68,7 @@ def findfeeds(url=None, disable_strict=False):
     for a in ahreftags:
         href = a.get("href", None)
         if href:
-            if "feed" in href or "rss" in href or "xml" in href:
+            if "feed" in href or "rss" in href or "atom" in href or "xml" in href:
                 discovered_feeds.append(urllib.parse.urljoin(url, href))
 
     for url in list(set(discovered_feeds)):


### PR DESCRIPTION
### Motivation
- Ensure Atom feeds are discovered the same way RSS feeds are by recognizing the "atom" keyword in HTML link/type hints and href scanning.

### Description
- Modify `bin/rssfind.py` to include `"atom"` when checking `<link rel="alternate">` `type` attributes and when scanning anchor `href` values for candidate feeds.

### Testing
- Ran `python3 -m py_compile bin/rssfind.py` which succeeded.
- Attempted `python3 bin/rssfind.py --help` but it failed in this environment due to a missing runtime dependency (`feedparser`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adad2460308324942fb1ca6a9f3d8f)