### PR TITLE
Improve feed discovery: recognize Atom, normalize types, and resolve relative URLs

### DIFF
--- a/bin/rssfind.py
+++ b/bin/rssfind.py
@@ -53,17 +53,29 @@ def findfeeds(url=None, disable_strict=False):
         for f in feed_urls:
             tag = f.get("type", None)
             if tag:
-                if "feed" in tag or "rss" in tag or "xml" in tag:
+                tag = tag.lower()
+                if (
+                    "feed" in tag
+                    or "rss" in tag
+                    or "atom" in tag
+                    or "xml" in tag
+                ):
                     href = f.get("href", None)
                     if href:
-                        discovered_feeds.append(href)
+                        discovered_feeds.append(urllib.parse.urljoin(url, href))
 
     ahreftags = html.findAll("a")
 
     for a in ahreftags:
         href = a.get("href", None)
         if href:
-            if "feed" in href or "rss" in href or "xml" in href:
+            href_lower = href.lower()
+            if (
+                "feed" in href_lower
+                or "rss" in href_lower
+                or "atom" in href_lower
+                or "xml" in href_lower
+            ):
                 discovered_feeds.append(urllib.parse.urljoin(url, href))
 
     for url in list(set(discovered_feeds)):


### PR DESCRIPTION
### Motivation
- Make feed detection more robust by recognizing Atom feeds, normalizing case for type/href checks, and ensuring discovered feed links are converted to absolute URLs.

### Description
- Lowercase the `type` attribute before matching and include `"atom"` in the content-type checks for `link[rel=alternate]` tags.
- Lowercase anchor `href` checks and include `"atom"` when heuristically filtering `a` tags for potential feeds.
- Resolve discovered feed `href` values to absolute URLs using `urllib.parse.urljoin(url, href)` before attempting to parse them with `feedparser`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adad2460308324942fb1ca6a9f3d8f)