### PR TITLE
rssfind: merge standard discovery results with brute-force (-b)

### DIFF
--- a/bin/rssfind.py
+++ b/bin/rssfind.py
@@ -157,15 +157,12 @@ if not options.link:
     parser.print_help()
     sys.exit(0)
 
-if not options.brute_force:
-    print(
-        json.dumps(
-            findfeeds(url=options.link, disable_strict=options.disable_strict)
-        ).decode("utf-8")
+feeds = findfeeds(url=options.link, disable_strict=options.disable_strict)
+
+if options.brute_force:
+    brute_force_feeds = brutefindfeeds(
+        url=options.link, disable_strict=options.disable_strict
     )
-else:
-    print(
-        json.dumps(
-            brutefindfeeds(url=options.link, disable_strict=options.disable_strict)
-        ).decode("utf-8")
-    )
+    feeds = list(set(feeds + brute_force_feeds))
+
+print(json.dumps(feeds).decode("utf-8"))


### PR DESCRIPTION
### Motivation
- Ensure the non-brute-force discovery results are included when `-b/--brute-force` is used so brute-force mode augments rather than replaces normal discovery.

### Description
- Always run `findfeeds()` for the provided `--link` and store its results before considering brute-force.
- When `--brute-force` is set, call `brutefindfeeds()` and merge its results with the normal discovery using a `set` to deduplicate.
- Output the combined feed list as JSON from `bin/rssfind.py` instead of choosing one discovery path or the other.
- Preserve the existing `--disable-strict` behavior for both discovery paths.

### Testing
- Ran `python3 -m py_compile bin/rssfind.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb03542ec832487cdc5a077609dd2)