### PR TITLE
Follow HTTP redirects in rssfind feed discovery

### DIFF
--- a/bin/rssfind.py
+++ b/bin/rssfind.py
@@ -42,9 +42,13 @@ def findfeeds(url=None, disable_strict=False):
         return None
 
     try:
-        raw = requests.get(url, headers=headers, timeout=10).text
+        response = requests.get(
+            url, headers=headers, timeout=10, allow_redirects=True
+        )
     except requests.RequestException:
         return []
+    raw = response.text
+    base_url = response.url
     results = []
     discovered_feeds = []
     html = bs4(raw, features="lxml")
@@ -62,7 +66,9 @@ def findfeeds(url=None, disable_strict=False):
                 ):
                     href = f.get("href", None)
                     if href:
-                        discovered_feeds.append(urllib.parse.urljoin(url, href))
+                        discovered_feeds.append(
+                            urllib.parse.urljoin(base_url, href)
+                        )
 
     ahreftags = html.findAll("a")
 
@@ -76,7 +82,7 @@ def findfeeds(url=None, disable_strict=False):
                 or "atom" in href_lower
                 or "xml" in href_lower
             ):
-                discovered_feeds.append(urllib.parse.urljoin(url, href))
+                discovered_feeds.append(urllib.parse.urljoin(base_url, href))
 
     for url in list(set(discovered_feeds)):
         f = feedparser.parse(url)
@@ -95,15 +101,23 @@ def brutefindfeeds(url=None, disable_strict=False):
         return None
     found_urls = []
     found_valid_feeds = []
-    parsed_url = urllib.parse.urlparse(url)
+    try:
+        base_response = requests.get(
+            url, headers=headers, timeout=10, allow_redirects=True
+        )
+    except requests.RequestException:
+        return []
+    parsed_url = urllib.parse.urlparse(base_response.url)
     for path in brute_force_urls:
         url = f"{parsed_url.scheme}://{parsed_url.hostname}/{path}"
         try:
-            r = requests.get(url, headers=headers, timeout=10)
+            r = requests.get(
+                url, headers=headers, timeout=10, allow_redirects=True
+            )
         except requests.RequestException:
             continue
         if r.status_code == 200:
-            found_urls.append(url)
+            found_urls.append(r.url)
     for url in list(set(found_urls)):
         f = feedparser.parse(url)
         if f.entries:


### PR DESCRIPTION
### Motivation
- Ensure RSS/Atom discovery works correctly for sites that redirect (for example `http`→`https` or canonical host redirects) by resolving discovered feed URLs against the final destination URL.
- Make brute-force probing use the canonical redirected host/scheme so constructed probe URLs are accurate for redirected sites.

### Description
- Updated `findfeeds` to call `requests.get(..., allow_redirects=True)`, capture `response.text` and use `response.url` as `base_url` when resolving `link` and `a[href]` feed candidates with `urllib.parse.urljoin`.
- Updated `brutefindfeeds` to first follow redirects for the input URL, parse the final `base_response.url` to derive the scheme/hostname for brute-force paths, and use `allow_redirects=True` for probe requests.
- Preserve the final redirected URL for successful brute-force matches by appending `r.url` to the discovered URLs list.
- Kept existing `disable_strict` behavior and feed validation via `feedparser.parse` unchanged.

### Testing
- Ran `python3 -m py_compile bin/rssfind.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb137a92c8324b61dfc1369a042db)