### PR TITLE
Add optional extended markdown output mode to rssmerge

### DIFF
--- a/bin/rssmerge.py
+++ b/bin/rssmerge.py
@@ -65,8 +65,21 @@ def RenderMerge(itemlist, output="text"):
             ).ctime()
             domain = urlparse(allitem[item[1]]["link"]).netloc
             print(f'- {domain} [{title}]({link}) @{timestamp}')
+            if options.markdown_extended:
+                extended_text = allitem[item[1]].get("extended", "")
+                if extended_text:
+                    print(f"  > {extended_text[: int(options.markdown_extended_size)]}")
             if i == int(options.maxitem):
                 break
+
+
+def extract_extended_text(entry):
+    if "content" in entry and len(entry.content):
+        raw_text = entry.content[0].value
+    else:
+        raw_text = getattr(entry, "summary", "")
+    cleantext = BeautifulSoup(raw_text, "lxml").text
+    return " ".join(cleantext.split())
 
 
 def parse_entry_epoch(entry):
@@ -101,6 +114,19 @@ parser.add_option(
     default="text",
     help="output format (text, phtml, markdown), default text",
 )
+parser.add_option(
+    "--markdown-extended",
+    action="store_true",
+    dest="markdown_extended",
+    default=False,
+    help="include extended summary/content text in markdown output",
+)
+parser.add_option(
+    "--markdown-extended-size",
+    dest="markdown_extended_size",
+    default=1000,
+    help="maximum size of extended text in markdown output, default 1000",
+)
 
 (options, args) = parser.parse_args()
 
@@ -123,6 +149,7 @@ for url in args:
         else:
             cleantext = BeautifulSoup(getattr(el, "summary", ""), "lxml").text
             allitem[linkkey]["title"] = cleantext[: int(options.summarysize)]
+        allitem[linkkey]["extended"] = extract_extended_text(el)
 
 itemlist = []
 


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to include more of an entry's text in Markdown output while keeping the current compact line format as the default.
- Allow callers to control how much extended text is included to avoid unexpectedly long outputs.

### Description
- Added a `--markdown-extended` flag to enable printing an indented quoted block of entry text below each Markdown item. 
- Added a `--markdown-extended-size` option (default `1000`) to cap the length of the extra text that is printed. 
- Implemented `extract_extended_text(entry)` which prefers `content` and falls back to `summary`, strips HTML via `BeautifulSoup`, and normalizes whitespace.
- Store the normalized extended text per entry in `allitem[<key>]['extended']` and render it when `--markdown-extended` is set, without changing the default output formatting.

### Testing
- Ran `python3 bin/rssmerge.py -h` to exercise CLI code paths, but execution failed in this environment due to missing dependency `feedparser` (environment limitation), so no runtime rendering tests could be completed automatically.
- No unit tests were added or available in the repository for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf2ae298883248e9d228c3e68af8c)