### PR TITLE
Default RSS title now uses directory name and hostname when -t is not provided

### DIFF
--- a/bin/rssdir.py
+++ b/bin/rssdir.py
@@ -8,6 +8,7 @@
 # or Atom output. Designed for quick static publishing workflows.
 
 import os, fnmatch
+import socket
 import time
 import sys
 import xml.etree.ElementTree as ET
@@ -129,7 +130,7 @@ parser.add_option(
     "-t",
     "--title",
     dest="title",
-    help="set a title to the rss feed, default using prefix",
+    help="set a title to the rss feed, default using directory and hostname",
     type="string",
 )
 parser.add_option(
@@ -179,11 +180,6 @@ if options.link is None:
 else:
     link = options.link
 
-if options.title is None:
-    title = options.prefix
-else:
-    title = options.title
-
 if options.maxitem is None:
     maxitem = 32
 else:
@@ -194,8 +190,17 @@ if not args:
     parser.print_help()
     sys.exit(0)
 
+source_directory = args[0]
+
+if options.title is None:
+    directory_name = os.path.basename(os.path.abspath(source_directory))
+    system_name = socket.gethostname()
+    title = f"{directory_name} on {system_name}"
+else:
+    title = options.title
+
 file_to_list = []
-for x in all_files(args[0]):
+for x in all_files(source_directory):
     file_to_list.append(x)
 
 mylist = date_files(file_to_list)


### PR DESCRIPTION
### Motivation
- Make the default feed title more informative when the user does not provide `-t/--title` by using the source directory name and the current system hostname.
- Avoid relying on the `prefix` option for the title so directory-based feeds are more descriptive for local/static use.

### Description
- Added `import socket` and compute `source_directory = args[0]` to reuse the parsed directory argument for both title generation and file traversal in `bin/rssdir.py`.
- When `-t/--title` is not provided the code now sets `title = "<directory_name> on <hostname>"` using `os.path.basename(os.path.abspath(source_directory))` and `socket.gethostname()`.
- Updated the `--title` help text to indicate the new fallback behavior and replaced direct uses of `args[0]` with `source_directory` for clarity.

### Testing
- Ran `python3 bin/rssdir.py <tmpdir>` and confirmed the generated feed `<title>` contains the directory name and hostname, and this test succeeded.
- Ran `python3 bin/rssdir.py -t 'Custom Title' <tmpdir>` and confirmed the explicit title takes precedence, and this test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf60c163883248dd3d6104477fe0e)