### PR TITLE
rssmerge: add optional --randomize flag to shuffle merged items

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rsscluster.py --interval 2 --maxitem 20 "http://paperbay.org/@a.rss" > adulau.xm
 
 ### rssmerge
 
-[`rssmerge.py`](https://github.com/adulau/rss-tools/blob/master/bin/rssmerge.py) aggregates multiple RSS/Atom feeds and merges items in reverse chronological order.
+[`rssmerge.py`](https://github.com/adulau/rss-tools/blob/master/bin/rssmerge.py) aggregates multiple RSS/Atom feeds and merges items in reverse chronological order. Use `--randomize` to shuffle merged items instead of sorting by date.
 
 Supported output formats:
 
@@ -82,6 +82,7 @@ Options:
                         maximum size of the summary if a title is not present
   -o OUTPUT, --output=OUTPUT
                         output format (text, phtml, markdown), default text
+  -r, --randomize       randomize merged items instead of date-sorted output
   --markdown-extended   include extended summary/content text in markdown output
   --markdown-extended-size=MARKDOWN_EXTENDED_SIZE
                         maximum size of extended text in markdown output, default 1000

--- a/bin/rssmerge.py
+++ b/bin/rssmerge.py
@@ -12,6 +12,7 @@ import feedparser
 import time
 import datetime
 import hashlib
+import random
 from optparse import OptionParser
 import html
 from bs4 import BeautifulSoup
@@ -111,6 +112,14 @@ parser.add_option(
     help="output format (text, phtml, markdown), default text",
 )
 parser.add_option(
+    "-r",
+    "--randomize",
+    action="store_true",
+    dest="randomize",
+    default=False,
+    help="randomize merged items instead of date-sorted output",
+)
+parser.add_option(
     "--markdown-extended",
     action="store_true",
     dest="markdown_extended",
@@ -155,5 +164,8 @@ for something in list(allitem.keys()):
 
 itemlist.sort()
 itemlist.reverse()
+
+if options.randomize:
+    random.shuffle(itemlist)
 
 RenderMerge(itemlist, options.output)


### PR DESCRIPTION
### Motivation
- Provide an option to output merged feed items in a randomized order instead of strict reverse-chronological order as requested in the issue tracker.
- Preserve existing default behavior (reverse-chronological) while offering a simple boolean switch to change ordering.

### Description
- Added `import random` and a new CLI boolean option `-r/--randomize` to `bin/rssmerge.py` to enable shuffling of merged items when set.
- The code still builds the `itemlist` and performs the existing `sort()`/`reverse()` steps, and then applies `random.shuffle(itemlist)` only when `options.randomize` is true.
- Updated `README.md` `rssmerge` section to document the new `--randomize` option and include it in the Usage/Options block.
- Modified files: `bin/rssmerge.py` and `README.md`.

### Testing
- Successfully ran `python3 -m py_compile bin/rssmerge.py` to verify the script compiles without syntax errors (success).
- Attempted `python3 bin/rssmerge.py --help` but it failed in this environment due to missing runtime dependency `feedparser` (failure due to environment, not the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5a367f588324819c7e512f6f8076)