### PR TITLE
Fix rsscluster timestamp type for final cluster

### DIFF
--- a/bin/rsscluster.py
+++ b/bin/rsscluster.py
@@ -175,7 +175,7 @@ if len(previousepoch) and len(clusteredepoch):
         + " to: "
         + str(endttimetuple.ctime())
     )
-    startdatelist = str(starttimetuple.strftime(pattern)), str(clusteredepoch[-1])
+    startdatelist = str(previousepoch[0]), str(clusteredepoch[-1])
     tcluster.append(startdatelist)
     del previousepoch[0 : len(previousepoch)]
     del clusteredepoch[0 : len(clusteredepoch)]


### PR DESCRIPTION
### Motivation
- `build_rss()` calls `float(bloodyitem[0])` and failed with `ValueError` because the final cluster stored a formatted datetime string instead of an epoch timestamp.

### Description
- Change the final cluster tuple to use the epoch value `previousepoch[0]` instead of `starttimetuple.strftime(pattern)` in `bin/rsscluster.py`, making all cluster first elements consistently be epoch seconds.

### Testing
- Compiled the script with `python3 -m compileall -q bin/rsscluster.py` which succeeded.
- Attempted a runtime invocation with `python3 bin/rsscluster.py "http://api.flickr.com/services/feeds/photos_public.gne?id=31797858@N00&lang=en-us&format=atom"` but the environment lacks the `feedparser` module so end-to-end execution against the live feed could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5bf68a6483248f85a943572c7a15)